### PR TITLE
Fix error message

### DIFF
--- a/src/common/Exception.cpp
+++ b/src/common/Exception.cpp
@@ -64,7 +64,7 @@ Exception::Exception(const char *fmt, ...)
 
 	#if LOVE_EMSCRIPTEN
 		// TODO: replace with a nice console.error call (ie figure out how to pass multi-line string to it properly)
-		std::cout << message;
+		std::cout << message << std::endl;
 		emscripten_run_script("alert('An error occurred before the game window could be initialised. Please check the console!')");
 	#endif
 

--- a/src/modules/filesystem/physfs/Filesystem.cpp
+++ b/src/modules/filesystem/physfs/Filesystem.cpp
@@ -555,7 +555,7 @@ std::string Filesystem::getRealDirectory(const char *filename) const
 	const char *dir = PHYSFS_getRealDir(filename);
 
 	if (dir == nullptr)
-		throw love::Exception("File does not exist on disk.");
+		throw love::Exception("File %s does not exist on disk.", filename);
 
 	return std::string(dir);
 }


### PR DESCRIPTION
This fixes the case where you get the alert `An error occurred before the game window could be initialised. Please check the console!` but then there's no error log in the console.

The problem was that the message being printed did not have a newline afterwards, so it never got flushed.

I also added a thing to Filesystem.cpp so that the error message says _which_ file is not found.